### PR TITLE
Update keyboard shortcuts for seeking

### DIFF
--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -118,7 +118,7 @@ export class VideoPlayer {
             // Fall back to regular video volume control
         }
     }
-    setVolume(volume) {
+    setVolume(volume, showIndicator = true) {
         // Clamp volume between 0 and 2 (0% to 200%)
         volume = Math.max(0, Math.min(2, volume));
         this.currentVolume = volume;
@@ -129,7 +129,9 @@ export class VideoPlayer {
             // Fallback to video element volume (capped at 1)
             this.videoElement.volume = Math.min(1, volume);
         }
-        this.showVolumeIndicator();
+        if (showIndicator) {
+            this.showVolumeIndicator();
+        }
         this.persistState();
     }
     adjustVolume(delta) {
@@ -255,17 +257,23 @@ export class VideoPlayer {
             else if (event.key === "PageUp") {
                 this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
             }
-            else if (event.ctrlKey && event.shiftKey && event.key === "ArrowRight") {
+            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowRight") {
                 this.advanceCurrentTime(300);
             }
-            else if (event.ctrlKey && event.shiftKey && event.key === "ArrowLeft") {
+            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-300);
             }
-            else if (event.ctrlKey && event.key === "ArrowRight") {
+            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowRight") {
                 this.advanceCurrentTime(60);
             }
-            else if (event.ctrlKey && event.key === "ArrowLeft") {
+            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-60);
+            }
+            else if (event.key === ",") {
+                this.advanceCurrentTime(-300);
+            }
+            else if (event.key === ".") {
+                this.advanceCurrentTime(300);
             }
             else if (event.shiftKey && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-5);
@@ -337,15 +345,6 @@ export class VideoPlayer {
             }
             else if (event.key === "ArrowDown") {
                 this.adjustVolume(-0.05); // Decrease by 5%
-            }
-            else if (event.key === "m") {
-                // Toggle mute
-                if (this.currentVolume > 0) {
-                    this.setVolume(0);
-                }
-                else {
-                    this.setVolume(1);
-                }
             }
             else {
                 handled = false;
@@ -538,7 +537,7 @@ export class VideoPlayer {
                 this.videoElement.currentTime = state.currentTime;
             }
             if (typeof state.volume === "number") {
-                this.setVolume(state.volume);
+                this.setVolume(state.volume, false);
             }
         }
     }

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -251,22 +251,16 @@ export class VideoPlayer {
             else if (event.key === "Insert") {
                 previousTrack(event);
             }
-            else if (event.key === "PageDown" || event.key === ".") {
+            else if (event.key === "PageDown" || event.key === "." || (((event.ctrlKey && event.shiftKey) || event.getModifierState("AltGraph")) && event.key === "ArrowRight")) {
                 this.advanceCurrentTime(clamp(this.videoElement.duration * 0.1, 0, 300));
             }
-            else if (event.key === "PageUp" || event.key === ",") {
+            else if (event.key === "PageUp" || event.key === "," || (((event.ctrlKey && event.shiftKey) || event.getModifierState("AltGraph")) && event.key === "ArrowLeft")) {
                 this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
             }
-            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowRight") {
-                this.advanceCurrentTime(300);
-            }
-            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowLeft") {
-                this.advanceCurrentTime(-300);
-            }
-            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowRight") {
+            else if (event.ctrlKey && event.key === "ArrowRight") {
                 this.advanceCurrentTime(60);
             }
-            else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowLeft") {
+            else if (event.ctrlKey && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-60);
             }
             else if (event.shiftKey && event.key === "ArrowLeft") {

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -251,10 +251,10 @@ export class VideoPlayer {
             else if (event.key === "Insert") {
                 previousTrack(event);
             }
-            else if (event.key === "PageDown") {
+            else if (event.key === "PageDown" || event.key === ".") {
                 this.advanceCurrentTime(clamp(this.videoElement.duration * 0.1, 0, 300));
             }
-            else if (event.key === "PageUp") {
+            else if (event.key === "PageUp" || event.key === ",") {
                 this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
             }
             else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowRight") {
@@ -268,12 +268,6 @@ export class VideoPlayer {
             }
             else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-60);
-            }
-            else if (event.key === ",") {
-                this.advanceCurrentTime(-300);
-            }
-            else if (event.key === ".") {
-                this.advanceCurrentTime(300);
             }
             else if (event.shiftKey && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-5);

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -286,9 +286,9 @@ export class VideoPlayer {
                 previousTrack(event);
             } else if (event.key === "Insert") {
                 previousTrack(event);
-            } else if (event.key === "PageDown") {
+            } else if (event.key === "PageDown" || event.key === ".") {
                 this.advanceCurrentTime(clamp(this.videoElement.duration * 0.1, 0, 300));
-            } else if (event.key === "PageUp") {
+            } else if (event.key === "PageUp" || event.key === ",") {
                 this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
             } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowRight") {
                 this.advanceCurrentTime(300);
@@ -298,10 +298,6 @@ export class VideoPlayer {
                 this.advanceCurrentTime(60);
             } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-60);
-            } else if (event.key === ",") {
-                this.advanceCurrentTime(-300);
-            } else if (event.key === ".") {
-                this.advanceCurrentTime(300);
             } else if (event.shiftKey && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-5);
             } else if (event.shiftKey && event.key === "ArrowRight") {

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -1,639 +1,635 @@
 import * as playerState from "./state.js";
 
 export class VideoPlayer {
-    private rootElement: HTMLElement;
-    private videoElement: HTMLVideoElement;
-    private progressElement: HTMLProgressElement;
-    private currentTimeElement: HTMLElement;
-    private totalTimeElement: HTMLElement;
-    private trackNameElement: HTMLElement;
-    private timerElement: HTMLElement;
-    private volumeElement: HTMLElement;
+  private rootElement: HTMLElement;
+  private videoElement: HTMLVideoElement;
+  private progressElement: HTMLProgressElement;
+  private currentTimeElement: HTMLElement;
+  private totalTimeElement: HTMLElement;
+  private trackNameElement: HTMLElement;
+  private timerElement: HTMLElement;
+  private volumeElement: HTMLElement;
 
-    private audioContext: AudioContext | null = null;
-    private gainNode: GainNode | null = null;
-    private sourceNode: MediaElementAudioSourceNode | null = null;
-    private currentVolume: number = 1.0;
+  private audioContext: AudioContext | null = null;
+  private gainNode: GainNode | null = null;
+  private sourceNode: MediaElementAudioSourceNode | null = null;
+  private currentVolume: number = 1.0;
 
-    private playlist: string[] = [];
-    private currentTrackIndex: number = -1;
-    private currentTrackName: string | undefined;
+  private playlist: string[] = [];
+  private currentTrackIndex: number = -1;
+  private currentTrackName: string | undefined;
 
-    private random: boolean = true;
-    private randomPlaylistHistoryIndexes: number[] = [];
-    private randomPlaylistQueueIndexes: number[] = [];
+  private random: boolean = true;
+  private randomPlaylistHistoryIndexes: number[] = [];
+  private randomPlaylistQueueIndexes: number[] = [];
 
-    private displayRemainingTime: boolean = true;
-    private mouseInactiveTimer: number | undefined;
+  private displayRemainingTime: boolean = true;
+  private mouseInactiveTimer: number | undefined;
 
-    // Auto-pause after 1 hour tracking
-    private totalPlaybackTime: number = 0; // in seconds
-    private lastPlaybackTimestamp: number | undefined;
-    private readonly maxPlaybackTime: number = 3600; // 1 hour in seconds
+  // Auto-pause after 1 hour tracking
+  private totalPlaybackTime: number = 0; // in seconds
+  private lastPlaybackTimestamp: number | undefined;
+  private readonly maxPlaybackTime: number = 3600; // 1 hour in seconds
 
-    // Track if we're waiting for the page to become visible to start playback
-    private pendingAutoPlay: boolean = false;
+  // Track if we're waiting for the page to become visible to start playback
+  private pendingAutoPlay: boolean = false;
 
-    constructor(rootElement: HTMLElement) {
-        this.rootElement = rootElement;
-        this.videoElement = document.createElement("video");
-        this.videoElement.controls = false;
-        this.rootElement.appendChild(this.videoElement);
+  constructor(rootElement: HTMLElement) {
+    this.rootElement = rootElement;
+    this.videoElement = document.createElement("video");
+    this.videoElement.controls = false;
+    this.rootElement.appendChild(this.videoElement);
 
-        rootElement.classList.add("video_player");
+    rootElement.classList.add("video_player");
 
-        // Initialize Web Audio API for volume amplification
-        this.initAudioContext();
+    // Initialize Web Audio API for volume amplification
+    this.initAudioContext();
 
-        this.trackNameElement = document.createElement("span");
-        this.trackNameElement.classList.add("trackname");
-        this.rootElement.appendChild(this.trackNameElement);
+    this.trackNameElement = document.createElement("span");
+    this.trackNameElement.classList.add("trackname");
+    this.rootElement.appendChild(this.trackNameElement);
 
-        this.timerElement = document.createElement("span");
-        this.timerElement.classList.add("timer");
-        this.rootElement.appendChild(this.timerElement);
+    this.timerElement = document.createElement("span");
+    this.timerElement.classList.add("timer");
+    this.rootElement.appendChild(this.timerElement);
 
-        this.volumeElement = document.createElement("span");
-        this.volumeElement.classList.add("volume");
-        this.rootElement.appendChild(this.volumeElement);
+    this.volumeElement = document.createElement("span");
+    this.volumeElement.classList.add("volume");
+    this.rootElement.appendChild(this.volumeElement);
 
-        const controls = document.createElement("div");
-        controls.classList.add("controls");
-        this.rootElement.appendChild(controls);
+    const controls = document.createElement("div");
+    controls.classList.add("controls");
+    this.rootElement.appendChild(controls);
 
-        this.currentTimeElement = document.createElement("span");
-        this.totalTimeElement = document.createElement("span");
-        this.progressElement = document.createElement("progress");
-        controls.appendChild(this.currentTimeElement);
-        controls.appendChild(this.progressElement);
-        controls.appendChild(this.totalTimeElement);
+    this.currentTimeElement = document.createElement("span");
+    this.totalTimeElement = document.createElement("span");
+    this.progressElement = document.createElement("progress");
+    controls.appendChild(this.currentTimeElement);
+    controls.appendChild(this.progressElement);
+    controls.appendChild(this.totalTimeElement);
 
-        this.registerEvents();
-        this.setupVisibilityHandling();
-        this.fetchPlaylists().then(playlists => {
-            if (playlists.length > 0) {
-                this.fetchPlaylistItems(playlists[0]).then(() => {
-                    this.restoreState();
-                    if (this.currentTrackIndex === -1) {
-                        this.nextTrack();
-                    }
-                });
-            }
-        });
-    }
-
-    private setupVisibilityHandling() {
-        // Handle page visibility changes
-        document.addEventListener("visibilitychange", () => {
-            if (!document.hidden && this.pendingAutoPlay) {
-                // Page became visible and we have pending autoplay
-                this.pendingAutoPlay = false;
-                this.videoElement.play().catch(e => {
-                    console.error("Failed to start autoplay:", e);
-                });
-            }
-        });
-    }
-
-    private tryAutoPlay() {
-        if (document.hidden) {
-            // Tab is not visible, mark as pending and wait for visibility
-            this.pendingAutoPlay = true;
-        } else {
-            // Tab is visible, start playing immediately
-            // Resume AudioContext if suspended
-            if (this.audioContext && this.audioContext.state === 'suspended') {
-                this.audioContext.resume().then(() => {
-                    this.videoElement.play().catch(e => {
-                        console.error("Failed to start autoplay:", e);
-                    });
-                });
-            } else {
-                this.videoElement.play().catch(e => {
-                    console.error("Failed to start autoplay:", e);
-                });
-            }
-        }
-    }
-
-    private displayTrackname() {
-        this.updateTrackNameDisplay();
-        this.updateTimerDisplay();
-    }
-
-    private initAudioContext() {
-        try {
-            this.audioContext = new AudioContext();
-            this.sourceNode = this.audioContext.createMediaElementSource(this.videoElement);
-            this.gainNode = this.audioContext.createGain();
-
-            this.sourceNode.connect(this.gainNode);
-            this.gainNode.connect(this.audioContext.destination);
-
-            // Set initial volume
-            this.gainNode.gain.value = this.currentVolume;
-        } catch (error) {
-            console.error("Failed to initialize Web Audio API:", error);
-            // Fall back to regular video volume control
-        }
-    }
-
-    private setVolume(volume: number, showIndicator: boolean = true) {
-        // Clamp volume between 0 and 2 (0% to 200%)
-        volume = Math.max(0, Math.min(2, volume));
-        this.currentVolume = volume;
-
-        if (this.gainNode) {
-            this.gainNode.gain.value = volume;
-        } else {
-            // Fallback to video element volume (capped at 1)
-            this.videoElement.volume = Math.min(1, volume);
-        }
-
-        if (showIndicator) {
-            this.showVolumeIndicator();
-        }
-        this.persistState();
-    }
-
-    private adjustVolume(delta: number) {
-        const newVolume = this.currentVolume + delta;
-        this.setVolume(newVolume);
-    }
-
-    private showVolumeIndicator() {
-        const volumePercent = Math.round(this.currentVolume * 100);
-        this.volumeElement.textContent = `🔊 ${volumePercent}%`;
-        this.volumeElement.classList.add("visible");
-
-        // Hide after 2 seconds
-        setTimeout(() => {
-            this.volumeElement.classList.remove("visible");
-        }, 2000);
-    }
-
-    private updateTrackNameDisplay() {
-        this.trackNameElement.textContent = this.currentTrackName || "";
-    }
-
-    private updateTimerDisplay() {
-        const remainingTime = this.maxPlaybackTime - this.totalPlaybackTime;
-        const minutes = Math.floor(remainingTime / 60);
-        const seconds = Math.floor(remainingTime % 60);
-        const timeString = `${minutes}:${seconds.toString().padStart(2, "0")}`;
-
-        this.timerElement.textContent = `⏱️ Auto-pause in ${timeString}`;
-    }
-
-    private displayCursor() {
-        this.rootElement.classList.remove("mouse-idle");
-        if (this.mouseInactiveTimer) {
-            clearTimeout(this.mouseInactiveTimer);
-        }
-
-        this.mouseInactiveTimer = setTimeout(() => this.rootElement.classList.add("mouse-idle"), 3000);
-    }
-
-    private registerEvents() {
-        this.totalTimeElement.addEventListener("click", () => {
-            this.displayRemainingTime = !this.displayRemainingTime;
-            this.updateTimeDisplay();
-            this.persistState();
-        });
-
-        this.progressElement.addEventListener("click", (e) => {
-            let offset = e.pageX - this.progressElement.offsetLeft;
-            if (this.progressElement.offsetParent instanceof HTMLElement) {
-                offset = offset - this.progressElement.offsetParent.offsetLeft;
-            }
-
-            const pos = offset / this.progressElement.offsetWidth;
-            this.videoElement.currentTime = pos * this.videoElement.duration;
-            this.videoElement.play();
-        });
-
-        this.rootElement.addEventListener("mousemove", () => this.displayCursor());
-        this.rootElement.addEventListener("click", () => this.displayCursor());
-
-        // Mouse wheel for volume control
-        this.rootElement.addEventListener("wheel", (event) => {
-            event.preventDefault();
-            const delta = event.deltaY > 0 ? -0.05 : 0.05; // Scroll down = quieter, scroll up = louder
-            this.adjustVolume(delta);
-        }, { passive: false });
-
-        this.videoElement.addEventListener("ended", () => {
+    this.registerEvents();
+    this.setupVisibilityHandling();
+    this.fetchPlaylists().then(playlists => {
+      if (playlists.length > 0) {
+        this.fetchPlaylistItems(playlists[0]).then(() => {
+          this.restoreState();
+          if (this.currentTrackIndex === -1) {
             this.nextTrack();
+          }
         });
+      }
+    });
+  }
 
-        this.videoElement.addEventListener("click", () => {
-            this.playPause();
+  private setupVisibilityHandling() {
+    // Handle page visibility changes
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden && this.pendingAutoPlay) {
+        // Page became visible and we have pending autoplay
+        this.pendingAutoPlay = false;
+        this.videoElement.play().catch(e => {
+          console.error("Failed to start autoplay:", e);
         });
+      }
+    });
+  }
 
-        this.videoElement.addEventListener("timeupdate", throttle(() => this.persistState(), 5000));
-
-        this.videoElement.addEventListener("timeupdate", () => {
-            this.updateTimeDisplay();
-            this.trackPlaybackTime();
+  private tryAutoPlay() {
+    if (document.hidden) {
+      // Tab is not visible, mark as pending and wait for visibility
+      this.pendingAutoPlay = true;
+    } else {
+      // Tab is visible, start playing immediately
+      // Resume AudioContext if suspended
+      if (this.audioContext && this.audioContext.state === 'suspended') {
+        this.audioContext.resume().then(() => {
+          this.videoElement.play().catch(e => {
+            console.error("Failed to start autoplay:", e);
+          });
         });
-
-        // Track when video starts playing
-        this.videoElement.addEventListener("play", () => {
-            this.lastPlaybackTimestamp = Date.now();
+      } else {
+        this.videoElement.play().catch(e => {
+          console.error("Failed to start autoplay:", e);
         });
+      }
+    }
+  }
 
-        // Track when video pauses
-        this.videoElement.addEventListener("pause", () => {
-            this.updatePlaybackTime();
-        });
+  private displayTrackname() {
+    this.updateTrackNameDisplay();
+    this.updateTimerDisplay();
+  }
 
-        document.addEventListener("keypress", (event) => {
-            if (event.code === "Space") {
-                this.playPause();
-                event.preventDefault();
-            }
-        });
+  private initAudioContext() {
+    try {
+      this.audioContext = new AudioContext();
+      this.sourceNode = this.audioContext.createMediaElementSource(this.videoElement);
+      this.gainNode = this.audioContext.createGain();
 
-        document.addEventListener("keydown", (event) => {
-            const nextTrack = (event: KeyboardEvent) => {
-                if (event.shiftKey || event.ctrlKey) {
-                    this.nextTrack(this.random ? "sequential" : "random");
-                } else {
-                    this.nextTrack();
-                }
-            };
+      this.sourceNode.connect(this.gainNode);
+      this.gainNode.connect(this.audioContext.destination);
 
-            const previousTrack = (event: KeyboardEvent) => {
-                if (event.shiftKey || event.ctrlKey) {
-                    this.previousTrack(this.random ? "sequential" : "random");
-                } else {
-                    this.previousTrack();
-                }
-            };
+      // Set initial volume
+      this.gainNode.gain.value = this.currentVolume;
+    } catch (error) {
+      console.error("Failed to initialize Web Audio API:", error);
+      // Fall back to regular video volume control
+    }
+  }
 
-            let handled = true;
-            if (event.key === "Home") {
-                this.videoElement.currentTime = 0;
-            } else if (event.key === "End") {
-                nextTrack(event);
-            } else if (event.key === "MediaTrackPrevious") {
-                previousTrack(event);
-            } else if (event.key === "MediaTrackNext") {
-                nextTrack(event);
-            } else if (event.key === "n") {
-                nextTrack(event);
-            } else if (event.key === "p") {
-                previousTrack(event);
-            } else if (event.key === "Insert") {
-                previousTrack(event);
-            } else if (event.key === "PageDown" || event.key === ".") {
-                this.advanceCurrentTime(clamp(this.videoElement.duration * 0.1, 0, 300));
-            } else if (event.key === "PageUp" || event.key === ",") {
-                this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
-            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowRight") {
-                this.advanceCurrentTime(300);
-            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowLeft") {
-                this.advanceCurrentTime(-300);
-            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowRight") {
-                this.advanceCurrentTime(60);
-            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowLeft") {
-                this.advanceCurrentTime(-60);
-            } else if (event.shiftKey && event.key === "ArrowLeft") {
-                this.advanceCurrentTime(-5);
-            } else if (event.shiftKey && event.key === "ArrowRight") {
-                this.advanceCurrentTime(5);
-            } else if (event.key === "ArrowLeft") {
-                this.advanceCurrentTime(-30);
-            } else if (event.key === "ArrowRight") {
-                this.advanceCurrentTime(30);
-            } else if (event.key === "r") {
-                this.setRandom(!this.random);
-            } else if (event.key === "0") {
-                this.setCurrentTime(0);
-            } else if (event.key === "1") {
-                this.setCurrentTime(this.videoElement.duration * 0.1);
-            } else if (event.key === "2") {
-                this.setCurrentTime(this.videoElement.duration * 0.2);
-            } else if (event.key === "3") {
-                this.setCurrentTime(this.videoElement.duration * 0.3);
-            } else if (event.key === "4") {
-                this.setCurrentTime(this.videoElement.duration * 0.4);
-            } else if (event.key === "5") {
-                this.setCurrentTime(this.videoElement.duration * 0.5);
-            } else if (event.key === "6") {
-                this.setCurrentTime(this.videoElement.duration * 0.6);
-            } else if (event.key === "7") {
-                this.setCurrentTime(this.videoElement.duration * 0.7);
-            } else if (event.key === "8") {
-                this.setCurrentTime(this.videoElement.duration * 0.8);
-            } else if (event.key === "9") {
-                this.setCurrentTime(this.videoElement.duration * 0.9);
-            } else if (event.key === "Delete") {
-                if (this.currentTrackName && confirm("delete " + this.currentTrackName)) {
-                    const currentTrack = this.currentTrackName;
-                    this.nextTrack();
-                    fetch("/files/" + encodeURIComponent(currentTrack), { method: "DELETE" })
-                        .then(response => {
-                            if (response.status >= 200 && response.status < 300) {
-                                return;
-                            }
+  private setVolume(volume: number, showIndicator: boolean = true) {
+    // Clamp volume between 0 and 2 (0% to 200%)
+    volume = Math.max(0, Math.min(2, volume));
+    this.currentVolume = volume;
 
-                            alert("Failed to delete " + currentTrack);
-                        })
-                        .catch(() => alert("Failed to delete " + currentTrack));
-                }
-            } else if (event.key === "t") {
-                document.location.href = "/tracks";
-            } else if (event.key === "b") {
-                document.location.href = "/tracks";
-            } else if (event.key === "ArrowUp") {
-                this.adjustVolume(0.05); // Increase by 5%
-            } else if (event.key === "ArrowDown") {
-                this.adjustVolume(-0.05); // Decrease by 5%
-            } else {
-                handled = false;
-            }
-
-            if (handled) {
-                event.preventDefault();
-                event.stopPropagation();
-            }
-        });
+    if (this.gainNode) {
+      this.gainNode.gain.value = volume;
+    } else {
+      // Fallback to video element volume (capped at 1)
+      this.videoElement.volume = Math.min(1, volume);
     }
 
-    private advanceCurrentTime(relativeTime: number) {
-        this.videoElement.currentTime += relativeTime;
-        this.updateTimeDisplay();
+    if (showIndicator) {
+      this.showVolumeIndicator();
+    }
+    this.persistState();
+  }
+
+  private adjustVolume(delta: number) {
+    const newVolume = this.currentVolume + delta;
+    this.setVolume(newVolume);
+  }
+
+  private showVolumeIndicator() {
+    const volumePercent = Math.round(this.currentVolume * 100);
+    this.volumeElement.textContent = `🔊 ${volumePercent}%`;
+    this.volumeElement.classList.add("visible");
+
+    // Hide after 2 seconds
+    setTimeout(() => {
+      this.volumeElement.classList.remove("visible");
+    }, 2000);
+  }
+
+  private updateTrackNameDisplay() {
+    this.trackNameElement.textContent = this.currentTrackName || "";
+  }
+
+  private updateTimerDisplay() {
+    const remainingTime = this.maxPlaybackTime - this.totalPlaybackTime;
+    const minutes = Math.floor(remainingTime / 60);
+    const seconds = Math.floor(remainingTime % 60);
+    const timeString = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+
+    this.timerElement.textContent = `⏱️ Auto-pause in ${timeString}`;
+  }
+
+  private displayCursor() {
+    this.rootElement.classList.remove("mouse-idle");
+    if (this.mouseInactiveTimer) {
+      clearTimeout(this.mouseInactiveTimer);
     }
 
-    private setCurrentTime(seconds: number) {
-        this.videoElement.currentTime = seconds;
-        this.updateTimeDisplay();
-    }
+    this.mouseInactiveTimer = setTimeout(() => this.rootElement.classList.add("mouse-idle"), 3000);
+  }
 
-    private updateTimeDisplay() {
-        if (isFinite(this.videoElement.duration)) {
-            function formatTime(seconds: number) {
-                return `${Math.floor(seconds / 60)}:${Math.floor(seconds % 60).toString().padStart(2, "0")}`;
-            }
+  private registerEvents() {
+    this.totalTimeElement.addEventListener("click", () => {
+      this.displayRemainingTime = !this.displayRemainingTime;
+      this.updateTimeDisplay();
+      this.persistState();
+    });
 
-            this.progressElement.value = this.videoElement.currentTime;
-            this.progressElement.max = this.videoElement.duration;
+    this.progressElement.addEventListener("click", (e) => {
+      let offset = e.pageX - this.progressElement.offsetLeft;
+      if (this.progressElement.offsetParent instanceof HTMLElement) {
+        offset = offset - this.progressElement.offsetParent.offsetLeft;
+      }
 
-            this.currentTimeElement.textContent = formatTime(this.videoElement.currentTime);
+      const pos = offset / this.progressElement.offsetWidth;
+      this.videoElement.currentTime = pos * this.videoElement.duration;
+      this.videoElement.play();
+    });
 
-            if (this.displayRemainingTime) {
-                this.totalTimeElement.textContent = "-" + formatTime(this.videoElement.duration - this.videoElement.currentTime);
-                this.totalTimeElement.title = formatTime(this.videoElement.duration);
-            } else {
-                this.totalTimeElement.textContent = formatTime(this.videoElement.duration);
-                this.totalTimeElement.title = "";
-            }
-        }
-        else {
-            this.progressElement.value = 0;
-            this.progressElement.max = 0;
-        }
-    }
+    this.rootElement.addEventListener("mousemove", () => this.displayCursor());
+    this.rootElement.addEventListener("click", () => this.displayCursor());
 
-    playPause() {
-        if (this.videoElement.paused || this.videoElement.ended) {
-            // Resume AudioContext if suspended (required by browser autoplay policies)
-            if (this.audioContext && this.audioContext.state === 'suspended') {
-                this.audioContext.resume();
-            }
-            this.videoElement.play();
+    // Mouse wheel for volume control
+    this.rootElement.addEventListener("wheel", (event) => {
+      event.preventDefault();
+      const delta = event.deltaY > 0 ? -0.05 : 0.05; // Scroll down = quieter, scroll up = louder
+      this.adjustVolume(delta);
+    }, { passive: false });
+
+    this.videoElement.addEventListener("ended", () => {
+      this.nextTrack();
+    });
+
+    this.videoElement.addEventListener("click", () => {
+      this.playPause();
+    });
+
+    this.videoElement.addEventListener("timeupdate", throttle(() => this.persistState(), 5000));
+
+    this.videoElement.addEventListener("timeupdate", () => {
+      this.updateTimeDisplay();
+      this.trackPlaybackTime();
+    });
+
+    // Track when video starts playing
+    this.videoElement.addEventListener("play", () => {
+      this.lastPlaybackTimestamp = Date.now();
+    });
+
+    // Track when video pauses
+    this.videoElement.addEventListener("pause", () => {
+      this.updatePlaybackTime();
+    });
+
+    document.addEventListener("keypress", (event) => {
+      if (event.code === "Space") {
+        this.playPause();
+        event.preventDefault();
+      }
+    });
+
+    document.addEventListener("keydown", (event) => {
+      const nextTrack = (event: KeyboardEvent) => {
+        if (event.shiftKey || event.ctrlKey) {
+          this.nextTrack(this.random ? "sequential" : "random");
         } else {
-            this.videoElement.pause();
+          this.nextTrack();
         }
-    }
+      };
 
-    async fetchPlaylists() {
-        const response = await fetch("/playlists");
-        const playlists = await response.json();
-        return playlists;
-    }
-
-    async fetchPlaylistItems(playlist: string) {
-        const response = await fetch(`/playlists/${encodeURIComponent(playlist)}/tracks`);
-        const tracks = await response.json();
-        this.playlist = tracks || [];
-    }
-
-    setTrackIndex(trackIndex: number) {
-        if (trackIndex < 0) {
-            trackIndex = this.playlist.length - trackIndex;
+      const previousTrack = (event: KeyboardEvent) => {
+        if (event.shiftKey || event.ctrlKey) {
+          this.previousTrack(this.random ? "sequential" : "random");
+        } else {
+          this.previousTrack();
         }
+      };
 
-        if (trackIndex < 0) {
-            trackIndex = 0;
+      let handled = true;
+      if (event.key === "Home") {
+        this.videoElement.currentTime = 0;
+      } else if (event.key === "End") {
+        nextTrack(event);
+      } else if (event.key === "MediaTrackPrevious") {
+        previousTrack(event);
+      } else if (event.key === "MediaTrackNext") {
+        nextTrack(event);
+      } else if (event.key === "n") {
+        nextTrack(event);
+      } else if (event.key === "p") {
+        previousTrack(event);
+      } else if (event.key === "Insert") {
+        previousTrack(event);
+      } else if (event.key === "PageDown" || event.key === "." || (((event.ctrlKey && event.shiftKey) || event.getModifierState("AltGraph")) && event.key === "ArrowRight")) {
+        this.advanceCurrentTime(clamp(this.videoElement.duration * 0.1, 0, 300));
+      } else if (event.key === "PageUp" || event.key === "," || (((event.ctrlKey && event.shiftKey) || event.getModifierState("AltGraph")) && event.key === "ArrowLeft")) {
+        this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
+      } else if (event.ctrlKey && event.key === "ArrowRight") {
+        this.advanceCurrentTime(60);
+      } else if (event.ctrlKey && event.key === "ArrowLeft") {
+        this.advanceCurrentTime(-60);
+      } else if (event.shiftKey && event.key === "ArrowLeft") {
+        this.advanceCurrentTime(-5);
+      } else if (event.shiftKey && event.key === "ArrowRight") {
+        this.advanceCurrentTime(5);
+      } else if (event.key === "ArrowLeft") {
+        this.advanceCurrentTime(-30);
+      } else if (event.key === "ArrowRight") {
+        this.advanceCurrentTime(30);
+      } else if (event.key === "r") {
+        this.setRandom(!this.random);
+      } else if (event.key === "0") {
+        this.setCurrentTime(0);
+      } else if (event.key === "1") {
+        this.setCurrentTime(this.videoElement.duration * 0.1);
+      } else if (event.key === "2") {
+        this.setCurrentTime(this.videoElement.duration * 0.2);
+      } else if (event.key === "3") {
+        this.setCurrentTime(this.videoElement.duration * 0.3);
+      } else if (event.key === "4") {
+        this.setCurrentTime(this.videoElement.duration * 0.4);
+      } else if (event.key === "5") {
+        this.setCurrentTime(this.videoElement.duration * 0.5);
+      } else if (event.key === "6") {
+        this.setCurrentTime(this.videoElement.duration * 0.6);
+      } else if (event.key === "7") {
+        this.setCurrentTime(this.videoElement.duration * 0.7);
+      } else if (event.key === "8") {
+        this.setCurrentTime(this.videoElement.duration * 0.8);
+      } else if (event.key === "9") {
+        this.setCurrentTime(this.videoElement.duration * 0.9);
+      } else if (event.key === "Delete") {
+        if (this.currentTrackName && confirm("delete " + this.currentTrackName)) {
+          const currentTrack = this.currentTrackName;
+          this.nextTrack();
+          fetch("/files/" + encodeURIComponent(currentTrack), { method: "DELETE" })
+            .then(response => {
+              if (response.status >= 200 && response.status < 300) {
+                return;
+              }
+
+              alert("Failed to delete " + currentTrack);
+            })
+            .catch(() => alert("Failed to delete " + currentTrack));
         }
+      } else if (event.key === "t") {
+        document.location.href = "/tracks";
+      } else if (event.key === "b") {
+        document.location.href = "/tracks";
+      } else if (event.key === "ArrowUp") {
+        this.adjustVolume(0.05); // Increase by 5%
+      } else if (event.key === "ArrowDown") {
+        this.adjustVolume(-0.05); // Decrease by 5%
+      } else {
+        handled = false;
+      }
 
-        trackIndex = trackIndex % this.playlist.length;
+      if (handled) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    });
+  }
 
-        const url = this.playlist[trackIndex];
-        this.currentTrackIndex = trackIndex;
-        this.currentTrackName = url;
-        this.updateTrackNameDisplay();
+  private advanceCurrentTime(relativeTime: number) {
+    this.videoElement.currentTime += relativeTime;
+    this.updateTimeDisplay();
+  }
 
-        this.videoElement.src = "files/" + encodeURIComponent(url);
-        this.updateDocumentTitle();
-        this.displayTrackname();
-        this.displayCursor(); // Show title for idle period when track changes
+  private setCurrentTime(seconds: number) {
+    this.videoElement.currentTime = seconds;
+    this.updateTimeDisplay();
+  }
 
-        // Clear time display while waiting for new track to load
-        this.currentTimeElement.textContent = "--:--";
-        this.totalTimeElement.textContent = "--:--";
+  private updateTimeDisplay() {
+    if (isFinite(this.videoElement.duration)) {
+      function formatTime(seconds: number) {
+        return `${Math.floor(seconds / 60)}:${Math.floor(seconds % 60).toString().padStart(2, "0")}`;
+      }
+
+      this.progressElement.value = this.videoElement.currentTime;
+      this.progressElement.max = this.videoElement.duration;
+
+      this.currentTimeElement.textContent = formatTime(this.videoElement.currentTime);
+
+      if (this.displayRemainingTime) {
+        this.totalTimeElement.textContent = "-" + formatTime(this.videoElement.duration - this.videoElement.currentTime);
+        this.totalTimeElement.title = formatTime(this.videoElement.duration);
+      } else {
+        this.totalTimeElement.textContent = formatTime(this.videoElement.duration);
         this.totalTimeElement.title = "";
-        this.progressElement.value = 0;
-        this.progressElement.max = 0;
+      }
+    }
+    else {
+      this.progressElement.value = 0;
+      this.progressElement.max = 0;
+    }
+  }
 
-        try {
-            this.tryAutoPlay();
-        } catch (e) {
-            console.error(e);
-        }
+  playPause() {
+    if (this.videoElement.paused || this.videoElement.ended) {
+      // Resume AudioContext if suspended (required by browser autoplay policies)
+      if (this.audioContext && this.audioContext.state === 'suspended') {
+        this.audioContext.resume();
+      }
+      this.videoElement.play();
+    } else {
+      this.videoElement.pause();
+    }
+  }
 
-        this.persistState();
+  async fetchPlaylists() {
+    const response = await fetch("/playlists");
+    const playlists = await response.json();
+    return playlists;
+  }
+
+  async fetchPlaylistItems(playlist: string) {
+    const response = await fetch(`/playlists/${encodeURIComponent(playlist)}/tracks`);
+    const tracks = await response.json();
+    this.playlist = tracks || [];
+  }
+
+  setTrackIndex(trackIndex: number) {
+    if (trackIndex < 0) {
+      trackIndex = this.playlist.length - trackIndex;
     }
 
-    nextTrack(mode: undefined | "sequential" | "random" = undefined) {
-        if (this.playlist.length === 0) {
-            return;
-        }
-
-        const finalMode = mode || (this.random ? "random" : "sequential");
-        if (finalMode === "random") {
-            this.randomPlaylistHistoryIndexes.push(this.currentTrackIndex);
-
-            let newIndex = this.randomPlaylistQueueIndexes.shift();
-            if (newIndex !== undefined) {
-                this.setTrackIndex(newIndex);
-                return;
-            }
-
-            newIndex = this.getTrackRandomIndex();
-            this.setTrackIndex(newIndex);
-        } else {
-            this.setTrackIndex(this.currentTrackIndex + 1);
-        }
+    if (trackIndex < 0) {
+      trackIndex = 0;
     }
 
-    private getTrackRandomIndex() {
-        // If we've played all tracks, clear history except the current track
-        if (this.randomPlaylistHistoryIndexes.length >= this.playlist.length - 1) {
-            const currentTrack = this.randomPlaylistHistoryIndexes[this.randomPlaylistHistoryIndexes.length - 1];
-            this.randomPlaylistHistoryIndexes = currentTrack !== undefined ? [currentTrack] : [];
-        }
+    trackIndex = trackIndex % this.playlist.length;
 
-        // Find a random track that hasn't been played recently
-        let index = Math.floor(Math.random() * this.playlist.length);
-        let attempts = 0;
-        const maxAttempts = this.playlist.length * 2;
+    const url = this.playlist[trackIndex];
+    this.currentTrackIndex = trackIndex;
+    this.currentTrackName = url;
+    this.updateTrackNameDisplay();
 
-        while (this.randomPlaylistHistoryIndexes.indexOf(index) !== -1 && attempts < maxAttempts) {
-            index = Math.floor(Math.random() * this.playlist.length);
-            attempts++;
-        }
+    this.videoElement.src = "files/" + encodeURIComponent(url);
+    this.updateDocumentTitle();
+    this.displayTrackname();
+    this.displayCursor(); // Show title for idle period when track changes
 
-        return index;
+    // Clear time display while waiting for new track to load
+    this.currentTimeElement.textContent = "--:--";
+    this.totalTimeElement.textContent = "--:--";
+    this.totalTimeElement.title = "";
+    this.progressElement.value = 0;
+    this.progressElement.max = 0;
+
+    try {
+      this.tryAutoPlay();
+    } catch (e) {
+      console.error(e);
     }
 
-    previousTrack(mode: undefined | "sequential" | "random" = undefined) {
-        const finalMode = mode || (this.random ? "random" : "sequential");
-        if (finalMode === "random") {
-            this.randomPlaylistQueueIndexes.unshift(this.currentTrackIndex);
+    this.persistState();
+  }
 
-            var previous = this.randomPlaylistHistoryIndexes.pop();
-            if (previous !== undefined) {
-                this.setTrackIndex(previous);
-                return;
-            }
-
-            const newIndex = this.getTrackRandomIndex();
-            this.setTrackIndex(newIndex);
-        } else {
-            this.setTrackIndex(this.currentTrackIndex - 1);
-        }
+  nextTrack(mode: undefined | "sequential" | "random" = undefined) {
+    if (this.playlist.length === 0) {
+      return;
     }
 
-    setRandom(random: boolean) {
-        this.random = random;
-        if (!random) {
-            this.randomPlaylistHistoryIndexes = [];
-            this.randomPlaylistQueueIndexes = [];
-        }
-        this.updateDocumentTitle();
+    const finalMode = mode || (this.random ? "random" : "sequential");
+    if (finalMode === "random") {
+      this.randomPlaylistHistoryIndexes.push(this.currentTrackIndex);
+
+      let newIndex = this.randomPlaylistQueueIndexes.shift();
+      if (newIndex !== undefined) {
+        this.setTrackIndex(newIndex);
+        return;
+      }
+
+      newIndex = this.getTrackRandomIndex();
+      this.setTrackIndex(newIndex);
+    } else {
+      this.setTrackIndex(this.currentTrackIndex + 1);
+    }
+  }
+
+  private getTrackRandomIndex() {
+    // If we've played all tracks, clear history except the current track
+    if (this.randomPlaylistHistoryIndexes.length >= this.playlist.length - 1) {
+      const currentTrack = this.randomPlaylistHistoryIndexes[this.randomPlaylistHistoryIndexes.length - 1];
+      this.randomPlaylistHistoryIndexes = currentTrack !== undefined ? [currentTrack] : [];
     }
 
-    private updateDocumentTitle() {
-        let value = this.currentTrackName || "";
-        value = value.split("/").pop() || value; // Keep only the file name, not the full path
+    // Find a random track that hasn't been played recently
+    let index = Math.floor(Math.random() * this.playlist.length);
+    let attempts = 0;
+    const maxAttempts = this.playlist.length * 2;
 
-        if (this.random) {
-            value = "🔀 " + value;
-        }
-
-        document.title = value;
+    while (this.randomPlaylistHistoryIndexes.indexOf(index) !== -1 && attempts < maxAttempts) {
+      index = Math.floor(Math.random() * this.playlist.length);
+      attempts++;
     }
 
-    private persistState() {
-        playerState.persistPlayerState({
-            random: this.random,
-            currentTrackIndex: this.currentTrackIndex,
-            randomPlaylistHistoryIndexes: this.randomPlaylistHistoryIndexes,
-            randomPlaylistQueueIndexes: this.randomPlaylistQueueIndexes,
-            showRemainingTime: this.displayRemainingTime,
-            currentTime: this.videoElement.currentTime,
-            volume: this.currentVolume
-        });
+    return index;
+  }
+
+  previousTrack(mode: undefined | "sequential" | "random" = undefined) {
+    const finalMode = mode || (this.random ? "random" : "sequential");
+    if (finalMode === "random") {
+      this.randomPlaylistQueueIndexes.unshift(this.currentTrackIndex);
+
+      var previous = this.randomPlaylistHistoryIndexes.pop();
+      if (previous !== undefined) {
+        this.setTrackIndex(previous);
+        return;
+      }
+
+      const newIndex = this.getTrackRandomIndex();
+      this.setTrackIndex(newIndex);
+    } else {
+      this.setTrackIndex(this.currentTrackIndex - 1);
+    }
+  }
+
+  setRandom(random: boolean) {
+    this.random = random;
+    if (!random) {
+      this.randomPlaylistHistoryIndexes = [];
+      this.randomPlaylistQueueIndexes = [];
+    }
+    this.updateDocumentTitle();
+  }
+
+  private updateDocumentTitle() {
+    let value = this.currentTrackName || "";
+    value = value.split("/").pop() || value; // Keep only the file name, not the full path
+
+    if (this.random) {
+      value = "🔀 " + value;
     }
 
-    private restoreState() {
-        const state = playerState.loadPlayerState();
-        if (state) {
-            if (typeof state.random === "boolean") {
-                this.random = state.random;
-            }
+    document.title = value;
+  }
 
-            if (typeof state.showRemainingTime === "boolean") {
-                this.displayRemainingTime = state.showRemainingTime;
-            }
+  private persistState() {
+    playerState.persistPlayerState({
+      random: this.random,
+      currentTrackIndex: this.currentTrackIndex,
+      randomPlaylistHistoryIndexes: this.randomPlaylistHistoryIndexes,
+      randomPlaylistQueueIndexes: this.randomPlaylistQueueIndexes,
+      showRemainingTime: this.displayRemainingTime,
+      currentTime: this.videoElement.currentTime,
+      volume: this.currentVolume
+    });
+  }
 
-            if (Array.isArray(state.randomPlaylistQueueIndexes)) {
-                this.randomPlaylistQueueIndexes = state.randomPlaylistQueueIndexes;
-            }
+  private restoreState() {
+    const state = playerState.loadPlayerState();
+    if (state) {
+      if (typeof state.random === "boolean") {
+        this.random = state.random;
+      }
 
-            if (Array.isArray(state.randomPlaylistHistoryIndexes)) {
-                this.randomPlaylistHistoryIndexes = state.randomPlaylistHistoryIndexes;
-            }
+      if (typeof state.showRemainingTime === "boolean") {
+        this.displayRemainingTime = state.showRemainingTime;
+      }
 
-            if (typeof state.currentTrackIndex === "number") {
-                this.setTrackIndex(state.currentTrackIndex);
-            }
+      if (Array.isArray(state.randomPlaylistQueueIndexes)) {
+        this.randomPlaylistQueueIndexes = state.randomPlaylistQueueIndexes;
+      }
 
-            if (typeof state.currentTime === "number") {
-                this.videoElement.currentTime = state.currentTime;
-            }
+      if (Array.isArray(state.randomPlaylistHistoryIndexes)) {
+        this.randomPlaylistHistoryIndexes = state.randomPlaylistHistoryIndexes;
+      }
 
-            if (typeof state.volume === "number") {
-                this.setVolume(state.volume, false);
-            }
-        }
+      if (typeof state.currentTrackIndex === "number") {
+        this.setTrackIndex(state.currentTrackIndex);
+      }
+
+      if (typeof state.currentTime === "number") {
+        this.videoElement.currentTime = state.currentTime;
+      }
+
+      if (typeof state.volume === "number") {
+        this.setVolume(state.volume, false);
+      }
     }
+  }
 
-    private trackPlaybackTime() {
-        if (!this.videoElement.paused && this.lastPlaybackTimestamp !== undefined) {
-            this.updatePlaybackTime();
-            this.updateTimerDisplay();
+  private trackPlaybackTime() {
+    if (!this.videoElement.paused && this.lastPlaybackTimestamp !== undefined) {
+      this.updatePlaybackTime();
+      this.updateTimerDisplay();
 
-            // Check if we've exceeded the max playback time
-            if (this.totalPlaybackTime >= this.maxPlaybackTime) {
-                this.videoElement.pause();
-                this.showAutoPauseMessage();
-            }
-        }
+      // Check if we've exceeded the max playback time
+      if (this.totalPlaybackTime >= this.maxPlaybackTime) {
+        this.videoElement.pause();
+        this.showAutoPauseMessage();
+      }
     }
+  }
 
-    private updatePlaybackTime() {
-        if (this.lastPlaybackTimestamp !== undefined) {
-            const now = Date.now();
-            const elapsedSeconds = (now - this.lastPlaybackTimestamp) / 1000;
-            this.totalPlaybackTime += elapsedSeconds;
-            this.lastPlaybackTimestamp = now;
-        }
+  private updatePlaybackTime() {
+    if (this.lastPlaybackTimestamp !== undefined) {
+      const now = Date.now();
+      const elapsedSeconds = (now - this.lastPlaybackTimestamp) / 1000;
+      this.totalPlaybackTime += elapsedSeconds;
+      this.lastPlaybackTimestamp = now;
     }
+  }
 
-    private showAutoPauseMessage() {
-        // Show a temporary message using the track name element
-        this.trackNameElement.textContent = "⏸️ Auto-paused after 1 hour of playback";
-        setTimeout(() => {
-            this.updateTrackNameDisplay();
-            this.updateTimerDisplay();
-        }, 5000);
-    }
+  private showAutoPauseMessage() {
+    // Show a temporary message using the track name element
+    this.trackNameElement.textContent = "⏸️ Auto-paused after 1 hour of playback";
+    setTimeout(() => {
+      this.updateTrackNameDisplay();
+      this.updateTimerDisplay();
+    }, 5000);
+  }
 }
 
 function throttle(mainFunction: Function, delay: number) {
-    let timerInstance: number | null = null;
-    return (...args: any[]) => {
-        if (timerInstance === null) {
-            mainFunction(...args);
-            timerInstance = setTimeout(() => {
-                timerInstance = null;
-            }, delay);
-        }
-    };
+  let timerInstance: number | null = null;
+  return (...args: any[]) => {
+    if (timerInstance === null) {
+      mainFunction(...args);
+      timerInstance = setTimeout(() => {
+        timerInstance = null;
+      }, delay);
+    }
+  };
 }
 
 function debounce(func: Function, timeout: number) {
-    let timer: number | undefined;
-    return (...args: any[]) => {
-        clearTimeout(timer);
-        timer = setTimeout(() => { func(...args); }, timeout);
-    };
+  let timer: number | undefined;
+  return (...args: any[]) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => { func(...args); }, timeout);
+  };
 }
 
 function clamp(number: number, min: number, max: number) {
-    return Math.max(min, Math.min(number, max));
+  return Math.max(min, Math.min(number, max));
 }

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -126,10 +126,10 @@ export class VideoPlayer {
             this.audioContext = new AudioContext();
             this.sourceNode = this.audioContext.createMediaElementSource(this.videoElement);
             this.gainNode = this.audioContext.createGain();
-            
+
             this.sourceNode.connect(this.gainNode);
             this.gainNode.connect(this.audioContext.destination);
-            
+
             // Set initial volume
             this.gainNode.gain.value = this.currentVolume;
         } catch (error) {
@@ -142,14 +142,14 @@ export class VideoPlayer {
         // Clamp volume between 0 and 2 (0% to 200%)
         volume = Math.max(0, Math.min(2, volume));
         this.currentVolume = volume;
-        
+
         if (this.gainNode) {
             this.gainNode.gain.value = volume;
         } else {
             // Fallback to video element volume (capped at 1)
             this.videoElement.volume = Math.min(1, volume);
         }
-        
+
         if (showIndicator) {
             this.showVolumeIndicator();
         }
@@ -165,7 +165,7 @@ export class VideoPlayer {
         const volumePercent = Math.round(this.currentVolume * 100);
         this.volumeElement.textContent = `🔊 ${volumePercent}%`;
         this.volumeElement.classList.add("visible");
-        
+
         // Hide after 2 seconds
         setTimeout(() => {
             this.volumeElement.classList.remove("visible");
@@ -181,7 +181,7 @@ export class VideoPlayer {
         const minutes = Math.floor(remainingTime / 60);
         const seconds = Math.floor(remainingTime % 60);
         const timeString = `${minutes}:${seconds.toString().padStart(2, "0")}`;
-        
+
         this.timerElement.textContent = `⏱️ Auto-pause in ${timeString}`;
     }
 
@@ -290,14 +290,18 @@ export class VideoPlayer {
                 this.advanceCurrentTime(clamp(this.videoElement.duration * 0.1, 0, 300));
             } else if (event.key === "PageUp") {
                 this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
-            } else if (event.ctrlKey && event.shiftKey && event.key === "ArrowRight") {
+            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowRight") {
                 this.advanceCurrentTime(300);
-            } else if (event.ctrlKey && event.shiftKey && event.key === "ArrowLeft") {
+            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.shiftKey && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-300);
-            } else if (event.ctrlKey && event.key === "ArrowRight") {
+            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowRight") {
                 this.advanceCurrentTime(60);
-            } else if (event.ctrlKey && event.key === "ArrowLeft") {
+            } else if ((event.ctrlKey || event.getModifierState("AltGraph")) && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-60);
+            } else if (event.key === ",") {
+                this.advanceCurrentTime(-300);
+            } else if (event.key === ".") {
+                this.advanceCurrentTime(300);
             } else if (event.shiftKey && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-5);
             } else if (event.shiftKey && event.key === "ArrowRight") {
@@ -350,13 +354,6 @@ export class VideoPlayer {
                 this.adjustVolume(0.05); // Increase by 5%
             } else if (event.key === "ArrowDown") {
                 this.adjustVolume(-0.05); // Decrease by 5%
-            } else if (event.key === "m") {
-                // Toggle mute
-                if (this.currentVolume > 0) {
-                    this.setVolume(0);
-                } else {
-                    this.setVolume(1);
-                }
             } else {
                 handled = false;
             }
@@ -497,7 +494,7 @@ export class VideoPlayer {
         let index = Math.floor(Math.random() * this.playlist.length);
         let attempts = 0;
         const maxAttempts = this.playlist.length * 2;
-        
+
         while (this.randomPlaylistHistoryIndexes.indexOf(index) !== -1 && attempts < maxAttempts) {
             index = Math.floor(Math.random() * this.playlist.length);
             attempts++;
@@ -593,7 +590,7 @@ export class VideoPlayer {
         if (!this.videoElement.paused && this.lastPlaybackTimestamp !== undefined) {
             this.updatePlaybackTime();
             this.updateTimerDisplay();
-            
+
             // Check if we've exceeded the max playback time
             if (this.totalPlaybackTime >= this.maxPlaybackTime) {
                 this.videoElement.pause();


### PR DESCRIPTION
This improves keyboard seeking ergonomics and removes a mute shortcut that conflicts with browser behavior.

## What changed
- Disabled `m` mute toggling in the player shortcut handler.
- Added fast seek with `AltGr + ArrowLeft/ArrowRight` (same behavior as `Ctrl + ArrowLeft/ArrowRight`).
- Added single-key seek shortcuts:
  - `,` seeks backward 5 minutes
  - `.` seeks forward 5 minutes
- Kept generated JavaScript in sync with the TypeScript source.

## Notes
- Existing seek shortcuts (`Arrow`, `Shift+Arrow`, `Ctrl+Arrow`, `Ctrl+Shift+Arrow`, `PageUp/PageDown`) are preserved.
- `m`/`Ctrl+m` are no longer handled by the app, so browser/default behavior applies.