### PR TITLE
Handle Safari autoplay failures with click-to-play fallback

### DIFF
--- a/Meziantou.OnlineVideoPlayer/wwwroot/app.css
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/app.css
@@ -116,6 +116,31 @@ body {
             opacity: 1;
         }
 
+    .video_player .autoplay-prompt {
+        color: white;
+        font-size: 1.4rem;
+        z-index: 2;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: rgba(0, 0, 0, 0.6);
+        padding: 12px 18px;
+        border-radius: 12px;
+        backdrop-filter: blur(20px) saturate(180%);
+        -webkit-backdrop-filter: blur(20px) saturate(180%);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.5);
+        text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.8);
+        opacity: 0;
+        transition: opacity 0.2s ease-in-out;
+        pointer-events: none;
+    }
+
+        .video_player .autoplay-prompt.visible {
+            opacity: 1;
+        }
+
     .video_player.mouse-idle {
         cursor: none;
     }

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -8,6 +8,7 @@ export class VideoPlayer {
     trackNameElement;
     timerElement;
     volumeElement;
+    autoplayPromptElement;
     audioContext = null;
     gainNode = null;
     sourceNode = null;
@@ -26,6 +27,7 @@ export class VideoPlayer {
     maxPlaybackTime = 3600; // 1 hour in seconds
     // Track if we're waiting for the page to become visible to start playback
     pendingAutoPlay = false;
+    autoplayBlocked = false;
     constructor(rootElement) {
         this.rootElement = rootElement;
         this.videoElement = document.createElement("video");
@@ -43,6 +45,9 @@ export class VideoPlayer {
         this.volumeElement = document.createElement("span");
         this.volumeElement.classList.add("volume");
         this.rootElement.appendChild(this.volumeElement);
+        this.autoplayPromptElement = document.createElement("span");
+        this.autoplayPromptElement.classList.add("autoplay-prompt");
+        this.rootElement.appendChild(this.autoplayPromptElement);
         const controls = document.createElement("div");
         controls.classList.add("controls");
         this.rootElement.appendChild(controls);
@@ -71,9 +76,7 @@ export class VideoPlayer {
             if (!document.hidden && this.pendingAutoPlay) {
                 // Page became visible and we have pending autoplay
                 this.pendingAutoPlay = false;
-                this.videoElement.play().catch(e => {
-                    console.error("Failed to start autoplay:", e);
-                });
+                this.startPlayback(true);
             }
         });
     }
@@ -84,20 +87,43 @@ export class VideoPlayer {
         }
         else {
             // Tab is visible, start playing immediately
-            // Resume AudioContext if suspended
-            if (this.audioContext && this.audioContext.state === 'suspended') {
-                this.audioContext.resume().then(() => {
-                    this.videoElement.play().catch(e => {
-                        console.error("Failed to start autoplay:", e);
-                    });
-                });
-            }
-            else {
-                this.videoElement.play().catch(e => {
-                    console.error("Failed to start autoplay:", e);
-                });
-            }
+            this.startPlayback(true);
         }
+    }
+    startPlayback(isAutoplayAttempt) {
+        const startPromise = this.audioContext && this.audioContext.state === "suspended"
+            ? this.audioContext.resume().then(() => this.videoElement.play())
+            : this.videoElement.play();
+        startPromise
+            .then(() => {
+            this.hideAutoplayPrompt();
+        })
+            .catch(error => {
+            if (isAutoplayAttempt && this.isExpectedAutoplayError(error)) {
+                this.showAutoplayPrompt();
+                return;
+            }
+            console.error("Failed to start playback:", error);
+        });
+    }
+    isExpectedAutoplayError(error) {
+        return error instanceof DOMException && (error.name === "NotAllowedError" || error.name === "NotSupportedError");
+    }
+    showAutoplayPrompt() {
+        this.autoplayBlocked = true;
+        this.autoplayPromptElement.textContent = "▶️ Autoplay blocked. Click to play.";
+        this.autoplayPromptElement.classList.add("visible");
+    }
+    hideAutoplayPrompt() {
+        this.autoplayBlocked = false;
+        this.autoplayPromptElement.classList.remove("visible");
+    }
+    retryPlaybackIfBlocked() {
+        if (!this.autoplayBlocked) {
+            return false;
+        }
+        this.startPlayback(false);
+        return true;
     }
     displayTrackname() {
         this.updateTrackNameDisplay();
@@ -177,10 +203,15 @@ export class VideoPlayer {
             }
             const pos = offset / this.progressElement.offsetWidth;
             this.videoElement.currentTime = pos * this.videoElement.duration;
-            this.videoElement.play();
+            this.startPlayback(false);
         });
         this.rootElement.addEventListener("mousemove", () => this.displayCursor());
-        this.rootElement.addEventListener("click", () => this.displayCursor());
+        this.rootElement.addEventListener("click", (event) => {
+            this.displayCursor();
+            if (event.target !== this.videoElement) {
+                this.retryPlaybackIfBlocked();
+            }
+        });
         // Mouse wheel for volume control
         this.rootElement.addEventListener("wheel", (event) => {
             event.preventDefault();
@@ -191,6 +222,9 @@ export class VideoPlayer {
             this.nextTrack();
         });
         this.videoElement.addEventListener("click", () => {
+            if (this.retryPlaybackIfBlocked()) {
+                return;
+            }
             this.playPause();
         });
         this.videoElement.addEventListener("timeupdate", throttle(() => this.persistState(), 5000));
@@ -200,6 +234,7 @@ export class VideoPlayer {
         });
         // Track when video starts playing
         this.videoElement.addEventListener("play", () => {
+            this.hideAutoplayPrompt();
             this.lastPlaybackTimestamp = Date.now();
         });
         // Track when video pauses
@@ -375,11 +410,7 @@ export class VideoPlayer {
     }
     playPause() {
         if (this.videoElement.paused || this.videoElement.ended) {
-            // Resume AudioContext if suspended (required by browser autoplay policies)
-            if (this.audioContext && this.audioContext.state === 'suspended') {
-                this.audioContext.resume();
-            }
-            this.videoElement.play();
+            this.startPlayback(false);
         }
         else {
             this.videoElement.pause();
@@ -417,6 +448,7 @@ export class VideoPlayer {
         this.totalTimeElement.title = "";
         this.progressElement.value = 0;
         this.progressElement.max = 0;
+        this.hideAutoplayPrompt();
         try {
             this.tryAutoPlay();
         }

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -9,6 +9,7 @@ export class VideoPlayer {
   private trackNameElement: HTMLElement;
   private timerElement: HTMLElement;
   private volumeElement: HTMLElement;
+  private autoplayPromptElement: HTMLElement;
 
   private audioContext: AudioContext | null = null;
   private gainNode: GainNode | null = null;
@@ -33,6 +34,7 @@ export class VideoPlayer {
 
   // Track if we're waiting for the page to become visible to start playback
   private pendingAutoPlay: boolean = false;
+  private autoplayBlocked: boolean = false;
 
   constructor(rootElement: HTMLElement) {
     this.rootElement = rootElement;
@@ -56,6 +58,10 @@ export class VideoPlayer {
     this.volumeElement = document.createElement("span");
     this.volumeElement.classList.add("volume");
     this.rootElement.appendChild(this.volumeElement);
+
+    this.autoplayPromptElement = document.createElement("span");
+    this.autoplayPromptElement.classList.add("autoplay-prompt");
+    this.rootElement.appendChild(this.autoplayPromptElement);
 
     const controls = document.createElement("div");
     controls.classList.add("controls");
@@ -88,9 +94,7 @@ export class VideoPlayer {
       if (!document.hidden && this.pendingAutoPlay) {
         // Page became visible and we have pending autoplay
         this.pendingAutoPlay = false;
-        this.videoElement.play().catch(e => {
-          console.error("Failed to start autoplay:", e);
-        });
+        this.startPlayback(true);
       }
     });
   }
@@ -101,19 +105,51 @@ export class VideoPlayer {
       this.pendingAutoPlay = true;
     } else {
       // Tab is visible, start playing immediately
-      // Resume AudioContext if suspended
-      if (this.audioContext && this.audioContext.state === 'suspended') {
-        this.audioContext.resume().then(() => {
-          this.videoElement.play().catch(e => {
-            console.error("Failed to start autoplay:", e);
-          });
-        });
-      } else {
-        this.videoElement.play().catch(e => {
-          console.error("Failed to start autoplay:", e);
-        });
-      }
+      this.startPlayback(true);
     }
+  }
+
+  private startPlayback(isAutoplayAttempt: boolean) {
+    const startPromise = this.audioContext && this.audioContext.state === "suspended"
+      ? this.audioContext.resume().then(() => this.videoElement.play())
+      : this.videoElement.play();
+
+    startPromise
+      .then(() => {
+        this.hideAutoplayPrompt();
+      })
+      .catch(error => {
+        if (isAutoplayAttempt && this.isExpectedAutoplayError(error)) {
+          this.showAutoplayPrompt();
+          return;
+        }
+
+        console.error("Failed to start playback:", error);
+      });
+  }
+
+  private isExpectedAutoplayError(error: unknown): boolean {
+    return error instanceof DOMException && (error.name === "NotAllowedError" || error.name === "NotSupportedError");
+  }
+
+  private showAutoplayPrompt() {
+    this.autoplayBlocked = true;
+    this.autoplayPromptElement.textContent = "▶️ Autoplay blocked. Click to play.";
+    this.autoplayPromptElement.classList.add("visible");
+  }
+
+  private hideAutoplayPrompt() {
+    this.autoplayBlocked = false;
+    this.autoplayPromptElement.classList.remove("visible");
+  }
+
+  private retryPlaybackIfBlocked() {
+    if (!this.autoplayBlocked) {
+      return false;
+    }
+
+    this.startPlayback(false);
+    return true;
   }
 
   private displayTrackname() {
@@ -209,11 +245,16 @@ export class VideoPlayer {
 
       const pos = offset / this.progressElement.offsetWidth;
       this.videoElement.currentTime = pos * this.videoElement.duration;
-      this.videoElement.play();
+      this.startPlayback(false);
     });
 
     this.rootElement.addEventListener("mousemove", () => this.displayCursor());
-    this.rootElement.addEventListener("click", () => this.displayCursor());
+    this.rootElement.addEventListener("click", (event) => {
+      this.displayCursor();
+      if (event.target !== this.videoElement) {
+        this.retryPlaybackIfBlocked();
+      }
+    });
 
     // Mouse wheel for volume control
     this.rootElement.addEventListener("wheel", (event) => {
@@ -227,6 +268,10 @@ export class VideoPlayer {
     });
 
     this.videoElement.addEventListener("click", () => {
+      if (this.retryPlaybackIfBlocked()) {
+        return;
+      }
+
       this.playPause();
     });
 
@@ -239,6 +284,7 @@ export class VideoPlayer {
 
     // Track when video starts playing
     this.videoElement.addEventListener("play", () => {
+      this.hideAutoplayPrompt();
       this.lastPlaybackTimestamp = Date.now();
     });
 
@@ -394,11 +440,7 @@ export class VideoPlayer {
 
   playPause() {
     if (this.videoElement.paused || this.videoElement.ended) {
-      // Resume AudioContext if suspended (required by browser autoplay policies)
-      if (this.audioContext && this.audioContext.state === 'suspended') {
-        this.audioContext.resume();
-      }
-      this.videoElement.play();
+      this.startPlayback(false);
     } else {
       this.videoElement.pause();
     }
@@ -443,6 +485,7 @@ export class VideoPlayer {
     this.totalTimeElement.title = "";
     this.progressElement.value = 0;
     this.progressElement.max = 0;
+    this.hideAutoplayPrompt();
 
     try {
       this.tryAutoPlay();


### PR DESCRIPTION
Safari can reject automatic `video.play()` calls during startup (`NotSupportedError` / autoplay policy), which left playback stopped and only logged an error. This change adds an explicit, user-driven recovery path so playback can continue with a clear prompt.

## What changed
- Centralized playback startup in a single helper that handles AudioContext resume + `play()` error handling.
- Treats expected autoplay-policy failures as non-noisy behavior and shows an overlay prompt: `Autoplay blocked. Click to play.`
- Retries playback when the user interacts (video click / root click / normal play flow), then clears the prompt on successful play.
- Added styling for the autoplay prompt overlay in `app.css`.
- Kept generated `video-player.js` synchronized with the TypeScript source.

## Notes for reviewers
- This preserves existing autoplay behavior when browsers allow it; the prompt is only shown when autoplay is rejected.
- `video-player.js` was updated directly to match `video-player.ts` in this environment.