### PR TITLE
Fix muted audio after output device reconnect

### DIFF
--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -73,12 +73,24 @@ export class VideoPlayer {
     setupVisibilityHandling() {
         // Handle page visibility changes
         document.addEventListener("visibilitychange", () => {
+            if (!document.hidden) {
+                this.recoverAudioOutput();
+            }
             if (!document.hidden && this.pendingAutoPlay) {
                 // Page became visible and we have pending autoplay
                 this.pendingAutoPlay = false;
                 this.startPlayback(true);
             }
         });
+        window.addEventListener("focus", () => {
+            this.recoverAudioOutput();
+        });
+        const mediaDevices = navigator.mediaDevices;
+        if (mediaDevices && typeof mediaDevices.addEventListener === "function") {
+            mediaDevices.addEventListener("devicechange", () => {
+                this.recoverAudioOutput();
+            });
+        }
     }
     tryAutoPlay() {
         if (document.hidden) {
@@ -91,6 +103,7 @@ export class VideoPlayer {
         }
     }
     startPlayback(isAutoplayAttempt) {
+        this.recoverAudioOutput();
         const startPromise = this.audioContext && this.audioContext.state === "suspended"
             ? this.audioContext.resume().then(() => this.videoElement.play())
             : this.videoElement.play();
@@ -142,6 +155,23 @@ export class VideoPlayer {
         catch (error) {
             console.error("Failed to initialize Web Audio API:", error);
             // Fall back to regular video volume control
+        }
+    }
+    recoverAudioOutput() {
+        this.videoElement.defaultMuted = false;
+        this.videoElement.muted = false;
+        if (this.gainNode) {
+            this.gainNode.gain.value = this.currentVolume;
+        }
+        else {
+            this.videoElement.volume = Math.min(1, this.currentVolume);
+        }
+        if (this.audioContext && this.audioContext.state === "suspended" && !this.videoElement.paused) {
+            this.audioContext.resume().catch(error => {
+                if (!this.isExpectedAutoplayError(error)) {
+                    console.error("Failed to resume audio context during output recovery:", error);
+                }
+            });
         }
     }
     setVolume(volume, showIndicator = true) {
@@ -225,6 +255,7 @@ export class VideoPlayer {
             if (this.retryPlaybackIfBlocked()) {
                 return;
             }
+            this.recoverAudioOutput();
             this.playPause();
         });
         this.videoElement.addEventListener("timeupdate", throttle(() => this.persistState(), 5000));
@@ -235,6 +266,7 @@ export class VideoPlayer {
         // Track when video starts playing
         this.videoElement.addEventListener("play", () => {
             this.hideAutoplayPrompt();
+            this.recoverAudioOutput();
             this.lastPlaybackTimestamp = Date.now();
         });
         // Track when video pauses

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -91,12 +91,27 @@ export class VideoPlayer {
   private setupVisibilityHandling() {
     // Handle page visibility changes
     document.addEventListener("visibilitychange", () => {
+      if (!document.hidden) {
+        this.recoverAudioOutput();
+      }
+
       if (!document.hidden && this.pendingAutoPlay) {
         // Page became visible and we have pending autoplay
         this.pendingAutoPlay = false;
         this.startPlayback(true);
       }
     });
+
+    window.addEventListener("focus", () => {
+      this.recoverAudioOutput();
+    });
+
+    const mediaDevices = navigator.mediaDevices;
+    if (mediaDevices && typeof mediaDevices.addEventListener === "function") {
+      mediaDevices.addEventListener("devicechange", () => {
+        this.recoverAudioOutput();
+      });
+    }
   }
 
   private tryAutoPlay() {
@@ -110,6 +125,8 @@ export class VideoPlayer {
   }
 
   private startPlayback(isAutoplayAttempt: boolean) {
+    this.recoverAudioOutput();
+
     const startPromise = this.audioContext && this.audioContext.state === "suspended"
       ? this.audioContext.resume().then(() => this.videoElement.play())
       : this.videoElement.play();
@@ -171,6 +188,25 @@ export class VideoPlayer {
     } catch (error) {
       console.error("Failed to initialize Web Audio API:", error);
       // Fall back to regular video volume control
+    }
+  }
+
+  private recoverAudioOutput() {
+    this.videoElement.defaultMuted = false;
+    this.videoElement.muted = false;
+
+    if (this.gainNode) {
+      this.gainNode.gain.value = this.currentVolume;
+    } else {
+      this.videoElement.volume = Math.min(1, this.currentVolume);
+    }
+
+    if (this.audioContext && this.audioContext.state === "suspended" && !this.videoElement.paused) {
+      this.audioContext.resume().catch(error => {
+        if (!this.isExpectedAutoplayError(error)) {
+          console.error("Failed to resume audio context during output recovery:", error);
+        }
+      });
     }
   }
 
@@ -272,6 +308,7 @@ export class VideoPlayer {
         return;
       }
 
+      this.recoverAudioOutput();
       this.playPause();
     });
 
@@ -285,6 +322,7 @@ export class VideoPlayer {
     // Track when video starts playing
     this.videoElement.addEventListener("play", () => {
       this.hideAutoplayPrompt();
+      this.recoverAudioOutput();
       this.lastPlaybackTimestamp = Date.now();
     });
 


### PR DESCRIPTION
## Why
When the page is opened without an available output device, connecting a headset later can leave playback effectively muted until the page is reloaded. This change makes audio output recover automatically when devices become available.

## What changed
- Added a centralized audio recovery path in the player that:
  - clears accidental muted state (`defaultMuted = false`, `muted = false`)
  - reapplies the current volume/gain settings
  - resumes the Web Audio context when playback is active and the context is suspended
- Triggered this recovery on output lifecycle and interaction paths:
  - `navigator.mediaDevices.devicechange` (when supported)
  - page visibility and window focus
  - playback start and click interactions
- Kept existing autoplay-blocked handling unchanged.

## Notes for reviewers
- The same logic was applied to both `wwwroot/video-player.ts` and the shipped `wwwroot/video-player.js` so runtime behavior matches source changes.
- Local .NET build could not be run in this environment because `dotnet` is unavailable.