### PR TITLE
Fix macOS large-seek keyboard shortcuts

### DIFF
--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -279,6 +279,7 @@ export class VideoPlayer {
                 event.preventDefault();
             }
         });
+        const isMacOS = navigator.platform.toLowerCase().includes("mac");
         document.addEventListener("keydown", (event) => {
             const nextTrack = (event) => {
                 if (event.shiftKey || event.ctrlKey) {
@@ -296,6 +297,7 @@ export class VideoPlayer {
                     this.previousTrack();
                 }
             };
+            const isLargeSeekModifierPressed = event.ctrlKey || (isMacOS && (event.metaKey || event.altKey));
             let handled = true;
             if (event.key === "Home") {
                 this.videoElement.currentTime = 0;
@@ -324,10 +326,10 @@ export class VideoPlayer {
             else if (event.key === "PageUp" || event.key === "," || (((event.ctrlKey && event.shiftKey) || event.getModifierState("AltGraph")) && event.key === "ArrowLeft")) {
                 this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
             }
-            else if (event.ctrlKey && event.key === "ArrowRight") {
+            else if (isLargeSeekModifierPressed && event.key === "ArrowRight") {
                 this.advanceCurrentTime(60);
             }
-            else if (event.ctrlKey && event.key === "ArrowLeft") {
+            else if (isLargeSeekModifierPressed && event.key === "ArrowLeft") {
                 this.advanceCurrentTime(-60);
             }
             else if (event.shiftKey && event.key === "ArrowLeft") {

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -338,6 +338,7 @@ export class VideoPlayer {
       }
     });
 
+    const isMacOS = navigator.platform.toLowerCase().includes("mac");
     document.addEventListener("keydown", (event) => {
       const nextTrack = (event: KeyboardEvent) => {
         if (event.shiftKey || event.ctrlKey) {
@@ -355,6 +356,7 @@ export class VideoPlayer {
         }
       };
 
+      const isLargeSeekModifierPressed = event.ctrlKey || (isMacOS && (event.metaKey || event.altKey));
       let handled = true;
       if (event.key === "Home") {
         this.videoElement.currentTime = 0;
@@ -374,9 +376,9 @@ export class VideoPlayer {
         this.advanceCurrentTime(clamp(this.videoElement.duration * 0.1, 0, 300));
       } else if (event.key === "PageUp" || event.key === "," || (((event.ctrlKey && event.shiftKey) || event.getModifierState("AltGraph")) && event.key === "ArrowLeft")) {
         this.advanceCurrentTime(-clamp(this.videoElement.duration * 0.1, 0, 300));
-      } else if (event.ctrlKey && event.key === "ArrowRight") {
+      } else if (isLargeSeekModifierPressed && event.key === "ArrowRight") {
         this.advanceCurrentTime(60);
-      } else if (event.ctrlKey && event.key === "ArrowLeft") {
+      } else if (isLargeSeekModifierPressed && event.key === "ArrowLeft") {
         this.advanceCurrentTime(-60);
       } else if (event.shiftKey && event.key === "ArrowLeft") {
         this.advanceCurrentTime(-5);


### PR DESCRIPTION
## Why
On macOS, `Ctrl+Left/Right` is often intercepted by the OS, so the player's 60-second seek shortcut is not reliably usable.

## What changed
- Kept the existing `Ctrl+Left/Right` behavior.
- Added macOS equivalents so `Cmd+Left/Right` and `Option+Left/Right` trigger the same 60-second seek action.
- Updated the TypeScript source and regenerated the compiled JavaScript output.

## Notes for reviewers
The change is intentionally scoped to the large-seek shortcut path only, so other keyboard shortcuts keep their current behavior.