### PR TITLE
Add Backspace as file delete shortcut

### DIFF
--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -305,7 +305,7 @@ export class VideoPlayer {
         <li><kbd>PageDown</kbd>, <kbd>.</kbd>, <kbd>Ctrl+Shift+ArrowRight</kbd>, <kbd>AltGr+ArrowRight</kbd> Seek forward 10%</li>
         <li><kbd>0</kbd>-<kbd>9</kbd> Jump to 0%-90%</li>
         <li><kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd> Volume +5% / -5%</li>
-        <li><kbd>Delete</kbd> Delete current file</li>
+        <li><kbd>Delete</kbd> / <kbd>Backspace</kbd> Delete current file</li>
         <li><kbd>T</kbd> / <kbd>B</kbd> Open tracks page</li>
       </ul>`;
     }
@@ -496,7 +496,7 @@ export class VideoPlayer {
             else if (event.key === "9") {
                 this.setCurrentTime(this.videoElement.duration * 0.9);
             }
-            else if (event.key === "Delete") {
+            else if (event.key === "Delete" || event.key === "Backspace") {
                 if (this.currentTrackName && confirm("delete " + this.currentTrackName)) {
                     const currentTrack = this.currentTrackName;
                     this.nextTrack();

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -357,7 +357,7 @@ export class VideoPlayer {
         <li><kbd>PageDown</kbd>, <kbd>.</kbd>, <kbd>Ctrl+Shift+ArrowRight</kbd>, <kbd>AltGr+ArrowRight</kbd> Seek forward 10%</li>
         <li><kbd>0</kbd>-<kbd>9</kbd> Jump to 0%-90%</li>
         <li><kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd> Volume +5% / -5%</li>
-        <li><kbd>Delete</kbd> Delete current file</li>
+        <li><kbd>Delete</kbd> / <kbd>Backspace</kbd> Delete current file</li>
         <li><kbd>T</kbd> / <kbd>B</kbd> Open tracks page</li>
       </ul>`;
   }
@@ -537,7 +537,7 @@ export class VideoPlayer {
         this.setCurrentTime(this.videoElement.duration * 0.8);
       } else if (event.key === "9") {
         this.setCurrentTime(this.videoElement.duration * 0.9);
-      } else if (event.key === "Delete") {
+      } else if (event.key === "Delete" || event.key === "Backspace") {
         if (this.currentTrackName && confirm("delete " + this.currentTrackName)) {
           const currentTrack = this.currentTrackName;
           this.nextTrack();


### PR DESCRIPTION
Typing ergonomics vary by keyboard, and only supporting `Delete` made file deletion less discoverable and less accessible on layouts where Backspace is the primary key users reach for.

This change extends the player keyboard handler to treat `Backspace` the same as `Delete` for deleting the current file, and updates the shortcuts help text to document both keys.

### Notes
- Updated both `video-player.ts` and committed `video-player.js` so behavior and shipped assets stay aligned.