### PR TITLE
Persist current video by path with index fallback

### DIFF
--- a/Meziantou.OnlineVideoPlayer/wwwroot/state.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/state.ts
@@ -1,6 +1,7 @@
 export interface VideoPlayerState {
     random: boolean | undefined;
     currentTrackIndex: number | undefined;
+    currentTrackPath: string | undefined;
     randomPlaylistHistoryIndexes: number[] | undefined;
     randomPlaylistQueueIndexes: number[] | undefined;
     showRemainingTime: boolean | undefined;

--- a/Meziantou.OnlineVideoPlayer/wwwroot/tracks.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/tracks.js
@@ -21,6 +21,7 @@ export class TrackList {
                 const track = e.target.textContent || "";
                 const state = loadPlayerState() || {};
                 state.currentTrackIndex = this.tracks.indexOf(track);
+                state.currentTrackPath = track;
                 state.currentTime = 0;
                 persistPlayerState(state);
             }

--- a/Meziantou.OnlineVideoPlayer/wwwroot/tracks.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/tracks.ts
@@ -26,6 +26,7 @@ export class TrackList {
 
                 const state = loadPlayerState() || ({} as VideoPlayerState);
                 state.currentTrackIndex = this.tracks.indexOf(track);
+                state.currentTrackPath = track;
                 state.currentTime = 0;
                 persistPlayerState(state);
             }

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -713,6 +713,7 @@ export class VideoPlayer {
         playerState.persistPlayerState({
             random: this.random,
             currentTrackIndex: this.currentTrackIndex,
+            currentTrackPath: this.currentTrackIndex >= 0 ? this.playlist[this.currentTrackIndex] : undefined,
             randomPlaylistHistoryIndexes: this.randomPlaylistHistoryIndexes,
             randomPlaylistQueueIndexes: this.randomPlaylistQueueIndexes,
             showRemainingTime: this.displayRemainingTime,
@@ -736,8 +737,18 @@ export class VideoPlayer {
             if (Array.isArray(state.randomPlaylistHistoryIndexes)) {
                 this.randomPlaylistHistoryIndexes = state.randomPlaylistHistoryIndexes;
             }
-            if (typeof state.currentTrackIndex === "number") {
-                this.setTrackIndex(state.currentTrackIndex);
+            let trackIndexToRestore;
+            if (typeof state.currentTrackPath === "string") {
+                const trackIndexFromPath = this.playlist.indexOf(state.currentTrackPath);
+                if (trackIndexFromPath !== -1) {
+                    trackIndexToRestore = trackIndexFromPath;
+                }
+            }
+            if (trackIndexToRestore === undefined && typeof state.currentTrackIndex === "number") {
+                trackIndexToRestore = state.currentTrackIndex;
+            }
+            if (typeof trackIndexToRestore === "number") {
+                this.setTrackIndex(trackIndexToRestore);
             }
             if (typeof state.currentTime === "number") {
                 this.videoElement.currentTime = state.currentTime;

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -781,6 +781,7 @@ export class VideoPlayer {
     playerState.persistPlayerState({
       random: this.random,
       currentTrackIndex: this.currentTrackIndex,
+      currentTrackPath: this.currentTrackIndex >= 0 ? this.playlist[this.currentTrackIndex] : undefined,
       randomPlaylistHistoryIndexes: this.randomPlaylistHistoryIndexes,
       randomPlaylistQueueIndexes: this.randomPlaylistQueueIndexes,
       showRemainingTime: this.displayRemainingTime,
@@ -809,8 +810,20 @@ export class VideoPlayer {
         this.randomPlaylistHistoryIndexes = state.randomPlaylistHistoryIndexes;
       }
 
-      if (typeof state.currentTrackIndex === "number") {
-        this.setTrackIndex(state.currentTrackIndex);
+      let trackIndexToRestore: number | undefined;
+      if (typeof state.currentTrackPath === "string") {
+        const trackIndexFromPath = this.playlist.indexOf(state.currentTrackPath);
+        if (trackIndexFromPath !== -1) {
+          trackIndexToRestore = trackIndexFromPath;
+        }
+      }
+
+      if (trackIndexToRestore === undefined && typeof state.currentTrackIndex === "number") {
+        trackIndexToRestore = state.currentTrackIndex;
+      }
+
+      if (typeof trackIndexToRestore === "number") {
+        this.setTrackIndex(trackIndexToRestore);
       }
 
       if (typeof state.currentTime === "number") {


### PR DESCRIPTION
## Why
Restoring playback by track index can resume the wrong video when playlist contents or ordering change between sessions.

## What changed
- Added `currentTrackPath` to persisted player state.
- Persist both the current track path and current track index.
- On startup, restore by matching `currentTrackPath` in the current playlist first.
- If the saved path is no longer present, fall back to `currentTrackIndex`.
- Updated track-list selection persistence to store `currentTrackPath` as well.
- Regenerated compiled JavaScript from the TypeScript changes.

## Notes
This is backward-compatible with existing saved state because index-based restore remains in place as fallback.