### PR TITLE
Improve delete failure clipboard fallback command

### DIFF
--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -585,16 +585,19 @@ export class VideoPlayer {
         }
     }
     async handleDeleteFailure(trackPath) {
-        const copiedToClipboard = await this.copyToClipboard(trackPath);
+        const command = `rm "${trackPath}"`;
+        console.error("Delete command:", command);
+        const copiedToClipboard = await this.copyToClipboard(command);
         if (copiedToClipboard) {
-            alert("Failed to delete " + trackPath + ". The path was copied to the clipboard.");
+            alert("Failed to delete " + trackPath + '. The command ' + command + " was copied to the clipboard.");
         }
         else {
-            alert("Failed to delete " + trackPath + ". Unable to copy the path to the clipboard.");
+            alert("Failed to delete " + trackPath + ". Unable to copy the command to the clipboard.");
         }
     }
     async copyToClipboard(value) {
         if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
+            console.error("Unable to copy value to clipboard:", value);
             return false;
         }
         try {
@@ -602,7 +605,7 @@ export class VideoPlayer {
             return true;
         }
         catch (error) {
-            console.error("Failed to copy path to clipboard:", error);
+            console.error("Failed to copy value to clipboard:", value, error);
             return false;
         }
     }

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -631,16 +631,19 @@ export class VideoPlayer {
   }
 
   private async handleDeleteFailure(trackPath: string) {
-    const copiedToClipboard = await this.copyToClipboard(trackPath);
+    const command = `rm "${trackPath}"`;
+    console.error("Delete command:", command);
+    const copiedToClipboard = await this.copyToClipboard(command);
     if (copiedToClipboard) {
-      alert("Failed to delete " + trackPath + ". The path was copied to the clipboard.");
+      alert("Failed to delete " + trackPath + '. The command ' + command + " was copied to the clipboard.");
     } else {
-      alert("Failed to delete " + trackPath + ". Unable to copy the path to the clipboard.");
+      alert("Failed to delete " + trackPath + ". Unable to copy the command to the clipboard.");
     }
   }
 
   private async copyToClipboard(value: string) {
     if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
+      console.error("Unable to copy value to clipboard:", value);
       return false;
     }
 
@@ -648,7 +651,7 @@ export class VideoPlayer {
       await navigator.clipboard.writeText(value);
       return true;
     } catch (error) {
-      console.error("Failed to copy path to clipboard:", error);
+      console.error("Failed to copy value to clipboard:", value, error);
       return false;
     }
   }


### PR DESCRIPTION
When track deletion fails, users need a ready-to-run command and better diagnostics in case clipboard access does not work.

This updates the delete-failure flow to build `rm "<path>"` and use that command consistently in the fallback path.

- Always logs the generated delete command to the browser console when handling delete failures.
- Copies the command (not just the raw path) to the clipboard.
- If clipboard support is missing or write fails, logs the exact command value that could not be copied.
- Updates alert text to refer to the command rather than the path.