### PR TITLE
Display file size in the video player

### DIFF
--- a/Meziantou.OnlineVideoPlayer/CustomJsonSerializationContext.cs
+++ b/Meziantou.OnlineVideoPlayer/CustomJsonSerializationContext.cs
@@ -3,6 +3,7 @@
 namespace Meziantou.OnlineVideoPlayer;
 
 [JsonSerializable(typeof(IEnumerable<string>))]
+[JsonSerializable(typeof(FileDetails))]
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(string))]
 internal sealed partial class CustomJsonSerializationContext : JsonSerializerContext;

--- a/Meziantou.OnlineVideoPlayer/FileDetails.cs
+++ b/Meziantou.OnlineVideoPlayer/FileDetails.cs
@@ -1,0 +1,3 @@
+namespace Meziantou.OnlineVideoPlayer;
+
+internal sealed record FileDetails(long Size);

--- a/Meziantou.OnlineVideoPlayer/Program.cs
+++ b/Meziantou.OnlineVideoPlayer/Program.cs
@@ -43,6 +43,13 @@ app.MapGet("files/{**path}", (HttpContext context, string path, IOptions<PlayerC
     return Results.File(fullPath, enableRangeProcessing: true);
 });
 
+app.MapGet("file-details/{**path}", (string path, IOptions<PlayerConfiguration> options) =>
+{
+    var fullPath = GetFullPath(path, options, writeAccess: false);
+    var details = new FileDetails(new FileInfo(fullPath).Length);
+    return Results.Json(details, CustomJsonSerializationContext.Default.FileDetails);
+});
+
 app.MapDelete("files/{**path}", (HttpContext context, ILogger<Program> logger, string path, IOptions<PlayerConfiguration> options) =>
 {
     var fullPath = GetFullPath(path, options, writeAccess: true);

--- a/Meziantou.OnlineVideoPlayer/wwwroot/app.css
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/app.css
@@ -68,12 +68,18 @@ body {
         text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8), -1px -1px 2px rgba(0, 0, 0, 0.5);
     }
 
+        .video_player .trackname .filesize {
+            display: block;
+            font-size: 1rem;
+            margin-top: 2px;
+        }
+
     .video_player .timer {
         color: white;
         font-size: 1.4rem;
         z-index: 1;
         position: absolute;
-        top: 65px;
+        top: 95px;
         left: 15px;
         max-width: calc(100vw - 30px);
         overflow: hidden;

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.js
@@ -6,6 +6,8 @@ export class VideoPlayer {
     currentTimeElement;
     totalTimeElement;
     trackNameElement;
+    trackTitleElement;
+    fileSizeElement;
     timerElement;
     volumeElement;
     autoplayPromptElement;
@@ -49,6 +51,11 @@ export class VideoPlayer {
         this.trackNameElement = document.createElement("span");
         this.trackNameElement.classList.add("trackname");
         this.rootElement.appendChild(this.trackNameElement);
+        this.trackTitleElement = document.createElement("span");
+        this.trackNameElement.appendChild(this.trackTitleElement);
+        this.fileSizeElement = document.createElement("span");
+        this.fileSizeElement.classList.add("filesize");
+        this.trackNameElement.appendChild(this.fileSizeElement);
         this.timerElement = document.createElement("span");
         this.timerElement.classList.add("timer");
         this.rootElement.appendChild(this.timerElement);
@@ -310,7 +317,23 @@ export class VideoPlayer {
       </ul>`;
     }
     updateTrackNameDisplay() {
-        this.trackNameElement.textContent = this.currentTrackName || "";
+        this.trackTitleElement.textContent = this.currentTrackName || "";
+    }
+    async updateFileDetails(trackPath) {
+        this.fileSizeElement.textContent = "";
+        try {
+            const response = await fetch("/file-details/" + encodeURIComponent(trackPath));
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            const details = await response.json();
+            if (this.currentTrackName === trackPath) {
+                this.fileSizeElement.textContent = formatFileSize(details.size);
+            }
+        }
+        catch (error) {
+            console.error("Failed to fetch file details:", error);
+        }
     }
     updateTimerDisplay() {
         const remainingTime = this.maxPlaybackTime - this.totalPlaybackTime;
@@ -626,6 +649,7 @@ export class VideoPlayer {
         this.currentTrackIndex = trackIndex;
         this.currentTrackName = url;
         this.updateTrackNameDisplay();
+        void this.updateFileDetails(url);
         this.videoElement.src = "files/" + encodeURIComponent(url);
         this.updateDocumentTitle();
         this.displayTrackname();
@@ -785,12 +809,22 @@ export class VideoPlayer {
     }
     showAutoPauseMessage() {
         // Show a temporary message using the track name element
-        this.trackNameElement.textContent = "⏸️ Auto-paused after 1 hour of playback";
+        this.trackTitleElement.textContent = "⏸️ Auto-paused after 1 hour of playback";
         setTimeout(() => {
             this.updateTrackNameDisplay();
             this.updateTimerDisplay();
         }, 5000);
     }
+}
+function formatFileSize(bytes) {
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    let unitIndex = 0;
+    while (bytes >= 1024 && unitIndex < units.length - 1) {
+        bytes /= 1024;
+        unitIndex++;
+    }
+    const value = Math.round(bytes * 10) / 10;
+    return `${value}${units[unitIndex]}`;
 }
 function throttle(mainFunction, delay) {
     let timerInstance = null;

--- a/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
+++ b/Meziantou.OnlineVideoPlayer/wwwroot/video-player.ts
@@ -1,5 +1,9 @@
 import * as playerState from "./state.js";
 
+interface FileDetails {
+  size: number;
+}
+
 export class VideoPlayer {
   private rootElement: HTMLElement;
   private videoElement: HTMLVideoElement;
@@ -7,6 +11,8 @@ export class VideoPlayer {
   private currentTimeElement: HTMLElement;
   private totalTimeElement: HTMLElement;
   private trackNameElement: HTMLElement;
+  private trackTitleElement: HTMLElement;
+  private fileSizeElement: HTMLElement;
   private timerElement: HTMLElement;
   private volumeElement: HTMLElement;
   private autoplayPromptElement: HTMLElement;
@@ -60,6 +66,13 @@ export class VideoPlayer {
     this.trackNameElement = document.createElement("span");
     this.trackNameElement.classList.add("trackname");
     this.rootElement.appendChild(this.trackNameElement);
+
+    this.trackTitleElement = document.createElement("span");
+    this.trackNameElement.appendChild(this.trackTitleElement);
+
+    this.fileSizeElement = document.createElement("span");
+    this.fileSizeElement.classList.add("filesize");
+    this.trackNameElement.appendChild(this.fileSizeElement);
 
     this.timerElement = document.createElement("span");
     this.timerElement.classList.add("timer");
@@ -363,7 +376,25 @@ export class VideoPlayer {
   }
 
   private updateTrackNameDisplay() {
-    this.trackNameElement.textContent = this.currentTrackName || "";
+    this.trackTitleElement.textContent = this.currentTrackName || "";
+  }
+
+  private async updateFileDetails(trackPath: string) {
+    this.fileSizeElement.textContent = "";
+
+    try {
+      const response = await fetch("/file-details/" + encodeURIComponent(trackPath));
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const details: FileDetails = await response.json();
+      if (this.currentTrackName === trackPath) {
+        this.fileSizeElement.textContent = formatFileSize(details.size);
+      }
+    } catch (error) {
+      console.error("Failed to fetch file details:", error);
+    }
   }
 
   private updateTimerDisplay() {
@@ -677,6 +708,7 @@ export class VideoPlayer {
     this.currentTrackIndex = trackIndex;
     this.currentTrackName = url;
     this.updateTrackNameDisplay();
+    void this.updateFileDetails(url);
 
     this.videoElement.src = "files/" + encodeURIComponent(url);
     this.updateDocumentTitle();
@@ -867,12 +899,24 @@ export class VideoPlayer {
 
   private showAutoPauseMessage() {
     // Show a temporary message using the track name element
-    this.trackNameElement.textContent = "⏸️ Auto-paused after 1 hour of playback";
+    this.trackTitleElement.textContent = "⏸️ Auto-paused after 1 hour of playback";
     setTimeout(() => {
       this.updateTrackNameDisplay();
       this.updateTimerDisplay();
     }, 5000);
   }
+}
+
+function formatFileSize(bytes: number) {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let unitIndex = 0;
+  while (bytes >= 1024 && unitIndex < units.length - 1) {
+    bytes /= 1024;
+    unitIndex++;
+  }
+
+  const value = Math.round(bytes * 10) / 10;
+  return `${value}${units[unitIndex]}`;
 }
 
 function throttle(mainFunction: Function, delay: number) {


### PR DESCRIPTION
## Summary
- Add a `file-details/{path}` endpoint that returns the selected media file size as JSON.
- Update the player UI to show the track title and file size on separate lines.
- Fetch and format the file size client-side when a track is selected.

## Testing
- Not run (not requested)